### PR TITLE
Add root directory as default member

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,5 @@ default-members = [
     "crates/vim9-lexer",
     "crates/vim9-parser",
     "crates/vim9-gen",
+    "."
 ]


### PR DESCRIPTION
The root directory isn't added to the default members by default, which
prevents creating an executable.
